### PR TITLE
Distributed Cloud: enhance glance to support distributed keystone

### DIFF
--- a/glance/registry/client/v1/api.py
+++ b/glance/registry/client/v1/api.py
@@ -136,9 +136,11 @@ def configure_registry_admin_creds():
         'password': CONF.admin_password,
         'username': CONF.admin_user,
         'tenant': CONF.admin_tenant_name,
+        'project_name': CONF.admin_tenant_name,
         'auth_url': os.getenv('OS_AUTH_URL') or CONF.auth_url,
         'strategy': strategy,
         'region': CONF.auth_region,
+        'use_user_token': False,
     }
 
 

--- a/glance/registry/client/v2/api.py
+++ b/glance/registry/client/v2/api.py
@@ -44,6 +44,7 @@ CONF.import_opt('auth_url', _registry_client)
 CONF.import_opt('auth_strategy', _registry_client)
 CONF.import_opt('auth_region', _registry_client)
 
+
 _CLIENT_CREDS = None
 _CLIENT_HOST = None
 _CLIENT_PORT = None
@@ -94,9 +95,11 @@ def configure_registry_admin_creds():
         'password': CONF.admin_password,
         'username': CONF.admin_user,
         'tenant': CONF.admin_tenant_name,
+        'project_name': CONF.admin_tenant_name,
         'auth_url': os.getenv('OS_AUTH_URL') or CONF.auth_url,
         'strategy': strategy,
         'region': CONF.auth_region,
+        'use_user_token': False,
     }
 
 

--- a/glance/tests/unit/v1/test_registry_client.py
+++ b/glance/tests/unit/v1/test_registry_client.py
@@ -905,9 +905,11 @@ class TestRegistryV1ClientApi(base.IsolatedUnitTest):
             'password': 'password',
             'username': 'user',
             'tenant': 'tenant',
+            'project_name': 'tenant',
             'auth_url': auth_url,
             'strategy': strategy,
-            'region': 'region'
+            'region': 'region',
+            'use_user_token': False
         }
 
     def test_configure_registry_admin_creds(self):
@@ -918,6 +920,7 @@ class TestRegistryV1ClientApi(base.IsolatedUnitTest):
         self.config(admin_tenant_name=expected['tenant'])
         self.config(auth_strategy=expected['strategy'])
         self.config(auth_region=expected['region'])
+        self.config(use_user_token=expected['use_user_token'])
         self.stubs.Set(os, 'getenv', lambda x: None)
 
         self.assertIsNone(rapi._CLIENT_CREDS)

--- a/glance/tests/unit/v2/test_registry_client.py
+++ b/glance/tests/unit/v2/test_registry_client.py
@@ -746,9 +746,11 @@ class TestRegistryV2ClientApi(base.IsolatedUnitTest):
             'password': 'password',
             'username': 'user',
             'tenant': 'tenant',
+            'project_name': 'tenant',
             'auth_url': auth_url,
             'strategy': strategy,
-            'region': 'region'
+            'region': 'region',
+            'use_user_token': False
         }
 
     def test_configure_registry_admin_creds(self):
@@ -759,6 +761,7 @@ class TestRegistryV2ClientApi(base.IsolatedUnitTest):
         self.config(admin_tenant_name=expected['tenant'])
         self.config(auth_strategy=expected['strategy'])
         self.config(auth_region=expected['region'])
+        self.config(use_user_token=expected['use_user_token'])
         self.stubs.Set(os, 'getenv', lambda x: None)
 
         self.assertIsNone(rapi._CLIENT_CREDS)


### PR DESCRIPTION
This patch enhanced glance to support distributed keystone in
Distributed Cloud. It naturally fixed the issue where VIM fails to get
image list on subcloud.

The solution is to enable "use_user_token = False" support in glance
authentication so that glance-api on subcloud can access
glance-registry on System Controller by username and password. This is
neccessary because the token from subcloud keystone is not valide on
System Controller keystone.

The patch also fixed glance tox failures introduced by the changes.

Closes-Bug: 1791833

Signed-off-by: Andy Ning <andy.ning@windriver.com>