### PR TITLE
add the ability to request HPET support

### DIFF
--- a/etc/metadefs/compute-tis-flavor.json
+++ b/etc/metadefs/compute-tis-flavor.json
@@ -121,8 +121,8 @@
             "type": "boolean",
             "default": "True"
         },
-        "sw:wrs:guest:hpet": {
-            "title": "Guest Hpet timer",
+        "hw:hpet": {
+            "title": "Guest Hpet Timer",
             "description": "Enables the Hpet timer for use by guests.",
             "type": "boolean",
             "default": "False"


### PR DESCRIPTION
Updated HPET timer extra spec name to “hw:hpet” to match
changes in nova. Also, some minor formatting fixes.

Closes bug: 1790961
https://bugs.launchpad.net/starlingx/+bug/1790961

To be upstreamed along with stx-nova commit e0e80c8