### PR TITLE
add hw:wrs:pci_numa_affinity flavor metadata

### DIFF
--- a/etc/metadefs/compute-tis-flavor.json
+++ b/etc/metadefs/compute-tis-flavor.json
@@ -83,6 +83,16 @@
             ],
             "default": "prefer" 
         },
+        "hw:wrs:pci_numa_affinity": {
+            "title": "PCI NUMA Affinity",
+            "description": "Specify how to select NUMA node(s) from host. Strict: requires a host NUMA node with direct access to a PCI interface.; Prefer: prefers a host NUMA node with direct access to a PCI interface. If none is available, another NUMA node can be used.",
+            "type": "string",
+            "enum": [
+                "strict",
+                "prefer"
+            ],
+            "default": "prefer"
+        },
         "hw:wrs:live_migration_timeout": {
             "title": "Live Migration Timeout",
             "type": "string",


### PR DESCRIPTION
At the time of the last rebase, the hw:wrs:pci_numa_affinity definition
was missed.  This needs to be defined along with the other hw:wrs
definitions in /etc/glance/metadefs (these may be removed in the future
as part of the upstreaming initiatives)

Closes bug: #1798128
Signed-off-by: Daniel Badea <daniel.badea@windriver.com>