### PR TITLE
Remove support for nova-local lvm backend for compute hosts

### DIFF
--- a/etc/metadefs/compute-tis-flavor.json
+++ b/etc/metadefs/compute-tis-flavor.json
@@ -23,7 +23,6 @@
             "type": "string",
             "enum": [
                 "remote",
-                "local_lvm",
                 "local_image"
             ],
             "default": "local_image"


### PR DESCRIPTION
This story tracks the removal of the nova-local lvm backend for compute
hosts. The lvm backend is no longer required; nova-local storage will
continue to support settings of "image" or "remote" backends.

This story will remove custom code related to lvm nova-local storage:
- this removes local_lvm from /etc/metadefs/compute-tis-flavor.json

DocImpact
Story: 2004427
Task: 28083

Signed-off-by: Jim Gauld <james.gauld@windriver.com>